### PR TITLE
remove deprecated array syntax

### DIFF
--- a/PiwikTracker.php
+++ b/PiwikTracker.php
@@ -516,7 +516,7 @@ class PiwikTracker
         if (strlen($domain) > 0) {
             $dl = strlen($domain) - 1;
             // remove trailing '.'
-            if ($domain{$dl} === '.') {
+            if ($domain[$dl] === '.') {
                 $domain = substr($domain, 0, $dl);
             }
             // remove leading '*'


### PR DESCRIPTION
for PHP 7.4 compatibility
See https://github.com/matomo-org/matomo/issues/14821#issuecomment-525812210 for more details.