### PR TITLE
Remove duplicate class PiwikTracker

### DIFF
--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -2050,10 +2050,3 @@ function Matomo_getUrlTrackGoal($idSite, $idGoal, $revenue = 0.0)
 
     return $tracker->getUrlTrackGoal($idGoal, $revenue);
 }
-
-/**
- * For BC only
- *
- * @deprecated use MatomoTracker instead
- */
-class PiwikTracker extends MatomoTracker {}


### PR DESCRIPTION
Solves #54 

The class PiwikTracker is declared in both PiwikTracker.php and MatomoTracker.php, but the latter is also included in PiwickTracker.php