### PR TITLE
Mark package as compatible with PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "source": "https://github.com/matomo-org/matomo-php-tracker"
     },
     "require": {
-        "php": "^5.3",
+        "php": ">=5.3",
         "ext-json": "*"
     },
     "suggest": {


### PR DESCRIPTION
Not sure if we already might want to set the requirement to `>=7.2`