### PR TITLE
Prevent double slashes

### DIFF
--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -1650,6 +1650,7 @@ class MatomoTracker
         if (strpos(self::$URL, '/matomo.php') === false
             && strpos(self::$URL, '/proxy-matomo.php') === false
         ) {
+            self::$URL = rtrim(self::$URL, '/');
             self::$URL .= '/matomo.php';
         }
 


### PR DESCRIPTION
Otherwise might generate a URL like https://example.com//matomo.php