### PR TITLE
Fix include_once warning Failed opening './PiwikTracker.php' for inclusion

### DIFF
--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -2058,5 +2058,5 @@ function Matomo_getUrlTrackGoal($idSite, $idGoal, $revenue = 0.0)
  * @deprecated
  */
 if (!class_exists('\PiwikTracker')) {
-    include_once('./PiwikTracker.php');
+    include_once('PiwikTracker.php');
 }

--- a/PiwikTracker.php
+++ b/PiwikTracker.php
@@ -12,7 +12,7 @@
  */
 
 if (!class_exists('\MatomoTracker')) {
-    include_once('./MatomoTracker.php');
+    include_once('MatomoTracker.php');
 }
 
 /**


### PR DESCRIPTION
Have been getting these warnings quite often and a user mentioned it recently as well. I reckon this should fix it

> Warning: include_once(): Failed opening './PiwikTracker.php' for inclusion (include_path='/vendor/pear/pear_exception:/vendor/pear/console_getopt:/vendor/pear/pear-core-minimal/src:/vendor/pear/archive_tar:.:/usr/local/Cellar/php/7.4.6_1/share/php/pear') in /vendor/matomo/matomo-php-tracker/MatomoTracker.php on line 2110