### PR TITLE
Method setRequestMethodNonBulk() added to allow (non bulk) POST requests

### DIFF
--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -1484,7 +1484,7 @@ class MatomoTracker
      * when using POST to prevent the loss of POST values. When using Log Analytics,
      * be aware that POST requests are not parseable/replayable.
      *
-     * @param string $method
+     * @param string $method Either 'POST' or 'GET'
      * @return $this
      */
     public function setRequestMethodNonBulk($method)

--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -1546,8 +1546,8 @@ class MatomoTracker
         }
 
         $proxy = $this->getProxy();
-		
-	$method = isset($this->requestMethod) ? $this->requestMethod : $method;
+
+        $method = isset($this->requestMethod) ? $this->requestMethod : $method;
 
         if (function_exists('curl_init') && function_exists('curl_exec')) {
             $options = array(

--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -1487,7 +1487,7 @@ class MatomoTracker
      * @param string $method
      * @return $this
      */
-    public function setRequestMethod($method)
+    public function setRequestMethodNonBulk($method)
     {
         $this->requestMethod = strtoupper($method) === 'POST' ? 'POST' : 'GET';
         return $this;

--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -1477,6 +1477,19 @@ class MatomoTracker
         $this->requestTimeout = $timeout;
         return $this;
     }
+	
+	/**
+     * Sets the request method (either GET or POST). POST is recommended when using
+     * setTokenAuth() to prevent the token from being recorded in server logs.
+	 *
+     * @param string $method
+     * @return $this
+     */
+    public function setRequestMethod($method)
+    {
+        $this->requestMethod = strtoupper($method) === 'POST' ? 'POST' : 'GET';
+        return $this;
+    }
 
     /**
      * If a proxy is needed to look up the address of the Matomo site, set it with this
@@ -1532,6 +1545,8 @@ class MatomoTracker
         }
 
         $proxy = $this->getProxy();
+		
+		$method = isset($this->requestMethod) ? $this->requestMethod : $method;
 
         if (function_exists('curl_init') && function_exists('curl_exec')) {
             $options = array(

--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -1547,7 +1547,7 @@ class MatomoTracker
 
         $proxy = $this->getProxy();
 
-        $method = isset($this->requestMethod) ? $this->requestMethod : $method;
+        $method = isset($this->requestMethod) && !$this->doBulkRequests ? $this->requestMethod : $method;
 
         if (function_exists('curl_init') && function_exists('curl_exec')) {
             $options = array(

--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -1481,7 +1481,8 @@ class MatomoTracker
 	/**
      * Sets the request method (either GET or POST). POST is recommended when using
      * setTokenAuth() to prevent the token from being recorded in server logs.
-	 *
+     * When using POST, to prevent loss of the POST values, avoid using redirects.
+     *
      * @param string $method
      * @return $this
      */
@@ -1546,7 +1547,7 @@ class MatomoTracker
 
         $proxy = $this->getProxy();
 		
-		$method = isset($this->requestMethod) ? $this->requestMethod : $method;
+	$method = isset($this->requestMethod) ? $this->requestMethod : $method;
 
         if (function_exists('curl_init') && function_exists('curl_exec')) {
             $options = array(


### PR DESCRIPTION
POST was already supported, because it's used for BulkTrack. This method should provide the option to choose POST in other scenarios (when using setTokenAuth for increased security for example).