### PR TITLE
Update MatomoTracker.php

### DIFF
--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -2076,13 +2076,24 @@ didn't change any existing VisitorId value */
     {
         $cookieExpire = $this->currentTs + $cookieTTL;
         if (!headers_sent()) {
-            setcookie(
-                $this->getCookieName($cookieName),
-                $cookieValue,
-                $cookieExpire,
-                $this->configCookiePath,
-                $this->configCookieDomain
-            );
+            if (version_compare(PHP_VERSION, '7.3') >= 0) {
+                setcookie($this->getCookieName($cookieName), $cookieValue, [
+                    'expires' => $cookieExpire,
+                    'path' => $this->configCookiePath,
+                    'domain' => $this->configCookieDomain,
+                    'secure' => true,
+                    'httponly' => false,
+                    'samesite' => 'Lax'
+                ]);
+            } else {
+                setcookie(
+                    $this->getCookieName($cookieName),
+                    $cookieValue,
+                    $cookieExpire,
+                    $this->configCookiePath,
+                    $this->configCookieDomain
+                );
+            }
         }
         return $this;
     }


### PR DESCRIPTION
Use the modern 7.3 PHP syntax for set cookie. This fixes the problem:

Cookie “___” will be soon rejected because it has the “SameSite” attribute set to “None” or an invalid value, without the “secure” attribute. To know more about the “SameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite