### PR TITLE
Fix for double newline issue when a redirect is used

### DIFF
--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -1708,15 +1708,21 @@ didn't change any existing VisitorId value */
             ob_start();
             $response = @curl_exec($ch);
             ob_end_clean();
+            
             $header = '';
             $content = '';
-            
+
             if ($response === false) {
                 throw new \RuntimeException(curl_error($ch));
             }
-            
+
             if (!empty($response)) {
-                list($header, $content) = explode("\r\n\r\n", $response, $limitCount = 2);
+                // extract header
+                $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+                $header = substr($response, 0, $headerSize);
+
+                // extract content
+                $content = substr($response, $headerSize);
             }
 
             $this->parseIncomingCookies(explode("\r\n", $header));


### PR DESCRIPTION
### Description:

This PR solves an issue discovered when a redirect is used, and multiple double newlines (`\r\n\r\n`) are added amongst the headers. As a result the previous method used to split the headers from the content meant that part of the header could still be included within the response content if there was multiple double newline (`\r\n\r\n`). This PR aims to solve this issue.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
