### PR TITLE
Couple of fixes for PHP 8.1

### DIFF
--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -82,9 +82,9 @@ class MatomoTracker
      */
     public function __construct($idSite, $apiUrl = '')
     {
-        $this->ecommerceItems = array();
+        $this->ecommerceItems = [];
         $this->attributionInfo = false;
-        $this->eventCustomVar = false;
+        $this->eventCustomVar = [];
         $this->forcedDatetime = false;
         $this->forcedNewVisit = false;
         $this->networkTime = false;
@@ -93,10 +93,10 @@ class MatomoTracker
         $this->domProcessingTime = false;
         $this->domCompletionTime = false;
         $this->onLoadTime = false;
-        $this->pageCustomVar = false;
-        $this->ecommerceView = array();
-        $this->customParameters = array();
-        $this->customDimensions = array();
+        $this->pageCustomVar = [];
+        $this->ecommerceView = [];
+        $this->customParameters = [];
+        $this->customDimensions = [];
         $this->customData = false;
         $this->hasCookies = false;
         $this->token_auth = false;
@@ -153,14 +153,14 @@ class MatomoTracker
         // Allow debug while blocking the request
         $this->requestTimeout = 600;
         $this->doBulkRequests = false;
-        $this->storedTrackingActions = array();
+        $this->storedTrackingActions = [];
 
         $this->sendImageResponse = true;
 
         $this->visitorCustomVar = $this->getCustomVariablesFromCookie();
 
-        $this->outgoingTrackerCookies = array();
-        $this->incomingTrackerCookies = array();
+        $this->outgoingTrackerCookies = [];
+        $this->incomingTrackerCookies = [];
     }
 
     /**
@@ -365,9 +365,9 @@ class MatomoTracker
      */
     public function clearCustomVariables()
     {
-        $this->visitorCustomVar = array();
-        $this->pageCustomVar = array();
-        $this->eventCustomVar = array();
+        $this->visitorCustomVar = [];
+        $this->pageCustomVar = [];
+        $this->eventCustomVar = [];
     }
 
     /**
@@ -2105,13 +2105,13 @@ didn't change any existing VisitorId value */
     }
 
     /**
-     * @return bool|mixed
+     * @return array
      */
     protected function getCustomVariablesFromCookie()
     {
         $cookie = $this->getCookieMatchingName('cvar');
         if (!$cookie) {
-            return false;
+            return [];
         }
 
         return json_decode($cookie, $assoc = true);


### PR DESCRIPTION
### Description:

Following warnings occurred while generating visits:

```
WARNING [2021-11-14 21:46:33] 24845  /srv/matomo/vendor/matomo/matomo-php-tracker/MatomoTracker.php(311): Deprecated - Automatic conversion of false to array is deprecated - Matomo 4.6.0-b4 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already)
WARNING [2021-11-14 21:46:33] 24845  /srv/matomo/vendor/matomo/matomo-php-tracker/MatomoTracker.php(307): Deprecated - Automatic conversion of false to array is deprecated - Matomo 4.6.0-b4 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already)
```

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
