### PR TITLE
Another PHP 8.1 fix

### DIFF
--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -1620,7 +1620,7 @@ didn't change any existing VisitorId value */
 
         $forcePostUrlEncoded = false;
         if (!$this->doBulkRequests) {
-            if (strtoupper($this->requestMethod) === 'POST') {
+            if (!empty($this->requestMethod) && strtoupper($this->requestMethod) === 'POST') {
                 // POST ALL parameters and have no GET parameters
                 $urlParts = explode('?', $url);
 


### PR DESCRIPTION
### Description:

Fixes this deprecation warning:
```
PHP Deprecated:  strtoupper(): Passing null to parameter #1 ($string) of type string is deprecated in /srv/matomo/vendor/matomo/matomo-php-tracker/MatomoTracker.php on line 1623
```

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
