### PR TITLE
Add function to set api url

### DIFF
--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -172,6 +172,11 @@ class MatomoTracker
         $this->incomingTrackerCookies = [];
     }
 
+    public function setApiUrl(string $url)
+    {
+        self::$URL = $url;
+    }
+
     /**
      * By default, Matomo expects utf-8 encoded values, for example
      * for the page URL parameter values, Page Title, etc.

--- a/tests/Unit/MatomoTrackerTest.php
+++ b/tests/Unit/MatomoTrackerTest.php
@@ -71,4 +71,14 @@ class MatomoTrackerTest extends TestCase
         $expected = 'http://mymatomo.com/matomo.php?idsite=1&rec=1&apiv=1&_idts=1583298245&_id=b446c233274f79f0&url=http%3A%2F%2Fsomesite.com&urlref=&action_name=test+title';
         $this->assertEquals($expected, $url);
     }
+
+    public function test_setApiUrl()
+    {
+        $newApiUrl = 'https://NEW-API-URL.com';
+        $tracker = new \MatomoTracker(1, self::TEST_URL);
+        $tracker->setApiUrl('https://NEW-API-URL.com');
+        $url = $tracker->getUrlTrackPageView('test title');
+
+        $this->assertSame(substr($url, 0, strlen($newApiUrl)), $newApiUrl);
+    }
 }

--- a/tests/Unit/MatomoTrackerTest.php
+++ b/tests/Unit/MatomoTrackerTest.php
@@ -76,7 +76,7 @@ class MatomoTrackerTest extends TestCase
     {
         $newApiUrl = 'https://NEW-API-URL.com';
         $tracker = new \MatomoTracker(1, self::TEST_URL);
-        $tracker->setApiUrl('https://NEW-API-URL.com');
+        $tracker->setApiUrl($newApiUrl);
         $url = $tracker->getUrlTrackPageView('test title');
 
         $this->assertSame(substr($url, 0, strlen($newApiUrl)), $newApiUrl);


### PR DESCRIPTION
### Description:

This PR adds a function to set the api url after initialization. We need this, because we serialize the tracker instance and dispatch it to a asynchronous external job.
After unserializing the tracker, the api url isn't available.  

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
