### PR TITLE
Support CURLOPT_CONNECTTIMEOUT

### DIFF
--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -161,6 +161,7 @@ class MatomoTracker
 
         // Allow debug while blocking the request
         $this->requestTimeout = 600;
+        $this->requestConnectTimeout = 0;
         $this->doBulkRequests = false;
         $this->storedTrackingActions = [];
 
@@ -620,7 +621,7 @@ class MatomoTracker
     }
 
     /**
-     * Disables the bulk request feature. Make sure to call `doBulkTrack()` before disabling it if you have stored  
+     * Disables the bulk request feature. Make sure to call `doBulkTrack()` before disabling it if you have stored
      * tracking actions previously as this method won't be sending any previously stored actions before disabling it.
      *
      */
@@ -1696,7 +1697,33 @@ didn't change any existing VisitorId value */
         $this->requestTimeout = $timeout;
         return $this;
     }
-	
+
+    /**
+     * Returns the maximum number of seconds the tracker will spend trying to connect to Matomo.
+     * Defaults to 0 seconds (unlimited).
+     */
+    public function getRequestConnectTimeout()
+    {
+        return $this->requestConnectTimeout;
+    }
+
+    /**
+     * Sets the maximum number of seconds that the tracker will spend tryint to connect to Matomo.
+     *
+     * @param int $timeout
+     * @return $this
+     * @throws Exception
+     */
+    public function setRequestConnectTimeout($timeout)
+    {
+        if (!is_int($timeout) || $timeout < 0) {
+            throw new Exception("Invalid value supplied for request connect timeout: $timeout");
+        }
+
+        $this->requestConnectTimeout = $timeout;
+        return $this;
+    }
+
 	/**
      * Sets the request method to POST, which is recommended when using setTokenAuth()
      * to prevent the token from being recorded in server logs. Avoid using redirects
@@ -1752,6 +1779,7 @@ didn't change any existing VisitorId value */
             CURLOPT_USERAGENT => $this->userAgent,
             CURLOPT_HEADER => true,
             CURLOPT_TIMEOUT => $this->requestTimeout,
+            CURLOPT_CONNECTTIMEOUT => $this->requestConnectTimeout,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HTTPHEADER => array(
                 'Accept-Language: ' . $this->acceptLanguage,
@@ -1902,7 +1930,7 @@ didn't change any existing VisitorId value */
             ob_start();
             $response = @curl_exec($ch);
             ob_end_clean();
-            
+
             $header = '';
             $content = '';
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "matomo/matomo-php-tracker",
+    "name": "vpapaloukas/matomo-php-tracker",
     "description": "PHP Client for Matomo Analytics Tracking API",
     "keywords": ["matomo","piwik","tracker","analytics"],
     "homepage": "https://matomo.org",


### PR DESCRIPTION
### Description:

Add requestConnectTimeout to support CURLOPT_CONNECTTIMEOUT (defaults as  of CURL to 0 -> unlimited)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
