### PR TITLE
add support for CURLOPT_CONNECTTIMEOUT

### DIFF
--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -1700,7 +1700,7 @@ didn't change any existing VisitorId value */
 	
     /**
      * Returns the maximum number of seconds the tracker will spend trying to connect to Matomo.
-     * Defaults to 0 seconds (unlimited).
+     * Defaults to 300 seconds.
      */
     public function getRequestConnectTimeout()
     {

--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -161,6 +161,7 @@ class MatomoTracker
 
         // Allow debug while blocking the request
         $this->requestTimeout = 600;
+        $this->requestConnectTimeout = 300;
         $this->doBulkRequests = false;
         $this->storedTrackingActions = [];
 
@@ -1697,6 +1698,32 @@ didn't change any existing VisitorId value */
         return $this;
     }
 	
+    /**
+     * Returns the maximum number of seconds the tracker will spend trying to connect to Matomo.
+     * Defaults to 0 seconds (unlimited).
+     */
+    public function getRequestConnectTimeout()
+    {
+        return $this->requestConnectTimeout;
+    }
+
+    /**
+     * Sets the maximum number of seconds that the tracker will spend tryint to connect to Matomo.
+     *
+     * @param int $timeout
+     * @return $this
+     * @throws Exception
+     */
+    public function setRequestConnectTimeout($timeout)
+    {
+        if (!is_int($timeout) || $timeout < 0) {
+            throw new Exception("Invalid value supplied for request connect timeout: $timeout");
+        }
+
+        $this->requestConnectTimeout = $timeout;
+        return $this;
+    }
+
 	/**
      * Sets the request method to POST, which is recommended when using setTokenAuth()
      * to prevent the token from being recorded in server logs. Avoid using redirects
@@ -1752,6 +1779,7 @@ didn't change any existing VisitorId value */
             CURLOPT_USERAGENT => $this->userAgent,
             CURLOPT_HEADER => true,
             CURLOPT_TIMEOUT => $this->requestTimeout,
+            CURLOPT_CONNECTTIMEOUT => $this->requestConnectTimeout,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HTTPHEADER => array(
                 'Accept-Language: ' . $this->acceptLanguage,


### PR DESCRIPTION
### Description:

add support for CURLOPT_CONNECTTIMEOUT. The default value it gets is the one set by curl lib (300 sec)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
