### PR TITLE
fix: Check for cURL error before throwing exception in sendRequest me…

### DIFF
--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -1962,8 +1962,11 @@ didn't change any existing VisitorId value */
             $content = '';
 
             if ($response === false) {
-                throw new \RuntimeException(curl_error($ch));
-            }
+                $curlError = curl_error($ch);
+                if (!empty($curlError)) {
+                    throw new \RuntimeException($curlError);
+                }
+            }            
 
             if (!empty($response)) {
                 // extract header


### PR DESCRIPTION
### Description:
This commit addresses an issue where an exception was being thrown unconditionally in the `sendRequest` method of the `MatomoTracker` class when a cURL request failed. The error handling logic now checks if `curl_error($ch)` returns a non-empty value before throwing a `\RuntimeException`. This ensures that exceptions are only thrown when there is an actual cURL error, preventing unnecessary exceptions from being raised. This change improves error handling and provides more accurate feedback when cURL requests fail.