### PR TITLE
Fix: Curl Connection remaining open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This is the Developer Changelog for Matomo PHP Tracker. All breaking changes or new features are listed below.
 
+## Matomo PHP Tracker 3.3.1
+### Fixed
+- closed curl connection
+
 ## Matomo PHP Tracker 3.3.0
 ### Removed
 - support for PHP versions lower than 7.2

--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -1958,8 +1958,6 @@ didn't change any existing VisitorId value */
             curl_setopt_array($ch, $options);
             ob_start();
             $response = @curl_exec($ch);
-            curl_close($ch);
-            ob_end_clean();
             
             $header = '';
 
@@ -1981,6 +1979,8 @@ didn't change any existing VisitorId value */
 
             $this->parseIncomingCookies(explode("\r\n", $header));
 
+            curl_close($ch);
+            ob_end_clean();
         } elseif (function_exists('stream_context_create')) {
             $stream_options = $this->prepareStreamOptions($method, $data, $forcePostUrlEncoded);
 

--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -1949,6 +1949,8 @@ didn't change any existing VisitorId value */
             }
         }
 
+        $content = '';
+
         if (function_exists('curl_init') && function_exists('curl_exec')) {
             $options = $this->prepareCurlOptions($url, $method, $data, $forcePostUrlEncoded);
 
@@ -1956,10 +1958,10 @@ didn't change any existing VisitorId value */
             curl_setopt_array($ch, $options);
             ob_start();
             $response = @curl_exec($ch);
+            curl_close($ch);
             ob_end_clean();
             
             $header = '';
-            $content = '';
 
             if ($response === false) {
                 $curlError = curl_error($ch);

--- a/MatomoTracker.php
+++ b/MatomoTracker.php
@@ -2022,28 +2022,30 @@ didn't change any existing VisitorId value */
             ob_start();
             $response = @curl_exec($ch);
             
-            $header = '';
+            try {
+                $header = '';
 
-            if ($response === false) {
-                $curlError = curl_error($ch);
-                if (!empty($curlError)) {
-                    throw new \RuntimeException($curlError);
+                if ($response === false) {
+                    $curlError = curl_error($ch);
+                    if (!empty($curlError)) {
+                        throw new \RuntimeException($curlError);
+                    }
                 }
-            }            
 
-            if (!empty($response)) {
-                // extract header
-                $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-                $header = substr($response, 0, $headerSize);
+                if (!empty($response)) {
+                    // extract header
+                    $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+                    $header = substr($response, 0, $headerSize);
 
-                // extract content
-                $content = substr($response, $headerSize);
+                    // extract content
+                    $content = substr($response, $headerSize);
+                }
+
+                $this->parseIncomingCookies(explode("\r\n", $header));
+            } finally {
+                curl_close($ch);
+                ob_end_clean();
             }
-
-            $this->parseIncomingCookies(explode("\r\n", $header));
-
-            curl_close($ch);
-            ob_end_clean();
         } elseif (function_exists('stream_context_create')) {
             $stream_options = $this->prepareStreamOptions($method, $data, $forcePostUrlEncoded);
 


### PR DESCRIPTION
### Description:

PR for the issue https://github.com/matomo-org/matomo-php-tracker/issues/128

I didn't implement the retry mechanism because, in my opinion, user who use the library should decide if he wants to do it. Also, I fixed a bug when `$content` variable is undefined.